### PR TITLE
Cosmetic change to avoid dangling suffix of ':' if source is nil

### DIFF
--- a/lib/opentelemetry_ecto.ex
+++ b/lib/opentelemetry_ecto.ex
@@ -59,7 +59,7 @@ defmodule OpentelemetryEcto do
       case Keyword.fetch(config, :span_prefix) do
         {:ok, prefix} -> prefix
         :error -> Enum.join(event, ".")
-      end <> ":#{source}"
+      end <> if source != nil, do: ":#{source}", else: ""
 
     time_unit = Keyword.get(config, :time_unit, :microsecond)
 


### PR DESCRIPTION
As it stands, when source is nil (which, for example, can happen if there is a
call to `Repo.transaction`), the name of the span ends in an odd ':'. This
removes that ':'.