### PR TITLE
Update telemetry dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule OpentelemetryEcto.MixProject do
 
   defp deps do
     [
-      {:telemetry, "~> 0.4.2"},
+      {:telemetry, "~> 0.4.2 or ~> 1.0.0"},
       {:opentelemetry_api, "~> 1.0.0-rc"},
       {:opentelemetry, "~> 1.0.0-rc"},
       {:ex_doc, "~> 0.24.0", only: [:dev], runtime: false},


### PR DESCRIPTION
As stated in the 1.0.0 telemetry [release](https://github.com/beam-telemetry/telemetry/releases/tag/v1.0.0) there are no changes from version 0.4.3, they simply marked the API as stable.
Using just `~> 0.4.2` for it breaks some compatibility with libraries declaring a `~> 1.0.X` dependency for telemetry.
I just did what they are doing in the other elixir projects that depend on telemetry (see for example [plug](https://github.com/elixir-plug/plug/blob/ff3925fd53682f8671fa4ea90573a8123d877739/mix.exs#L46))